### PR TITLE
Command close before getting exit code

### DIFF
--- a/src/main/java/com/plugin/sshjplugin/model/SSHJExec.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJExec.java
@@ -111,7 +111,7 @@ public class SSHJExec extends SSHJBase implements SSHJEnvironments{
                         .copy();
 
 
-                //cmd.join(commandTimeout, TimeUnit.SECONDS);
+                cmd.close();
                 exitStatus = cmd.getExitStatus();
 
             }


### PR DESCRIPTION
This is to avoid random null value on exit code just as the javacod suggest it

![imagen](https://user-images.githubusercontent.com/50217398/106934114-7e311300-66f8-11eb-8a97-8233e916e861.png)

![imagen](https://user-images.githubusercontent.com/50217398/106934185-96089700-66f8-11eb-87f0-eab69d458605.png)

