### PR TITLE
Use framework in context instead of passing it in the constructor.

### DIFF
--- a/src/main/java/com/plugin/sshjplugin/SSHJFileCopierPlugin.java
+++ b/src/main/java/com/plugin/sshjplugin/SSHJFileCopierPlugin.java
@@ -65,17 +65,6 @@ public class SSHJFileCopierPlugin extends BaseFileCopier implements MultiFileCop
             .frameworkMapping(SSHJNodeExecutorPlugin.CONFIG_RETRY_COUNTER, SSHJNodeExecutorPlugin.FWK_PROP_RETRY_COUNTER)
             .build();
 
-
-
-    private Framework framework;
-
-    public SSHJFileCopierPlugin() {
-    }
-
-    public SSHJFileCopierPlugin(Framework framework) {
-        this.framework = framework;
-    }
-
     @Override
     public Description getDescription() {
         return DESC;
@@ -139,7 +128,7 @@ public class SSHJFileCopierPlugin extends BaseFileCopier implements MultiFileCop
                         );
 
         SSHJScp scp;
-        SSHJConnectionParameters connectionInfo = new SSHJConnectionParameters(node, framework, context);
+        SSHJConnectionParameters connectionInfo = new SSHJConnectionParameters(node, context);
 
         try {
             if (null != scriptfile && scriptfile.isDirectory()) {
@@ -198,7 +187,7 @@ public class SSHJFileCopierPlugin extends BaseFileCopier implements MultiFileCop
         }
 
         final SSHJScp scp;
-        final SSHJConnectionParameters connectionInfo = new SSHJConnectionParameters(node, framework, context);
+        final SSHJConnectionParameters connectionInfo = new SSHJConnectionParameters(node, context);
 
 
         try {

--- a/src/main/java/com/plugin/sshjplugin/SSHJNodeExecutorPlugin.java
+++ b/src/main/java/com/plugin/sshjplugin/SSHJNodeExecutorPlugin.java
@@ -100,14 +100,6 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, Describable {
     public static final String CON_TIMEOUT_MESSAGE =
             "Connection timeout.";
 
-    private Framework framework;
-
-
-    public SSHJNodeExecutorPlugin(Framework framework) {
-        this.framework = framework;
-    }
-
-
     public static final Property SSH_AUTH_TYPE_PROP = PropertyUtil.select(CONFIG_AUTHENTICATION, "SSH Authentication",
             "Type of SSH Authentication to use",
             true, SSHJConnection.AuthenticationType.privateKey.toString(), Arrays.asList(SSHJConnection.AuthenticationType.values()), null, null);
@@ -221,7 +213,7 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, Describable {
 
         final ExecutionListener listener = context.getExecutionListener();
 
-        SSHJConnectionParameters connectionInfo = new SSHJConnectionParameters(node, framework, context);
+        SSHJConnectionParameters connectionInfo = new SSHJConnectionParameters(node, context);
 
         long contimeout = connectionInfo.getConnectTimeout();
         long commandtimeout = connectionInfo.getCommandTimeout();
@@ -247,7 +239,7 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, Describable {
             sshexec.execute(connection);
             success = true;
         } catch (Exception e) {
-            final ExtractFailure extractJschFailure = extractFailure(e, node, commandtimeout, contimeout, framework);
+            final ExtractFailure extractJschFailure = extractFailure(e, node, commandtimeout, contimeout, context.getFramework());
             errormsg = extractJschFailure.getErrormsg();
             failureReason = extractJschFailure.getReason();
             context.getExecutionListener().log(

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJConnectionParameters.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJConnectionParameters.java
@@ -22,10 +22,10 @@ public class SSHJConnectionParameters implements SSHJConnection{
     private ExecutionContext context;
     private PropertyResolver propertyResolver;
 
-    public SSHJConnectionParameters(INodeEntry node, Framework framework, ExecutionContext context) {
+    public SSHJConnectionParameters(INodeEntry node, ExecutionContext context) {
         this.node = node;
         this.context = context;
-        this.framework = framework;
+        this.framework = context.getFramework();
 
         propertyResolver = new PropertyResolver(node, framework, context);
     }

--- a/src/test/groovy/com/plugin/sshjplugin/SSHJNodeExecutorPluginSpec.groovy
+++ b/src/test/groovy/com/plugin/sshjplugin/SSHJNodeExecutorPluginSpec.groovy
@@ -80,7 +80,7 @@ class SSHJNodeExecutorPluginSpec extends Specification {
 
 
         }
-        def example = new SSHJNodeExecutorPlugin(framework)
+        def example = new SSHJNodeExecutorPlugin()
 
 
         /*


### PR DESCRIPTION
Clean up inconsistent framework access.