### PR TITLE
RUN-1445:Uss Delegate OutputStream to wrap the real OutputStream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ configurations{
 dependencies {
 
     pluginLibs group: 'com.hierynomus', name: 'sshj', version: '0.33.0', ext: 'jar'
+    pluginLibs group: 'com.hierynomus', name: 'asn-one', version: '0.6.0', ext: 'jar'
     pluginLibs group: 'net.i2p.crypto', name: 'eddsa', version: '0.3.0', ext: 'jar'
     pluginLibs group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.61', ext: 'jar'
     pluginLibs group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.61', ext: 'jar'

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJExec.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJExec.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-
 public class SSHJExec extends SSHJBase implements SSHJEnvironments {
 
     private String command = null;
@@ -102,8 +101,6 @@ public class SSHJExec extends SSHJBase implements SSHJEnvironments {
                 pluginLogger.log(3, "["+getPluginName()+"]  capturing output" );
 
                 SSHJPluginLoggerFactory sshjLogger = new SSHJPluginLoggerFactory(pluginLogger);
-
-
 
                 new StreamCopier(cmd.getInputStream(), outputBuf, sshjLogger)
                         .bufSize(cmd.getLocalMaxPacketSize())

--- a/src/main/java/com/plugin/sshjplugin/util/DelegateOutputStream.java
+++ b/src/main/java/com/plugin/sshjplugin/util/DelegateOutputStream.java
@@ -3,10 +3,19 @@ package com.plugin.sshjplugin.util;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * This is a custom OutputStream which delegate a target OutputStream passed into the constructor at creation time.
+ *
+ * We need this delegate to pass it into StreamCopier because StreamCopier will close the OutputStream if it reaches the end of the InputStream.
+ * But we need to keep the OutputStream open the whole lifecycle of the plugin, so we can receive output from the following executions instead of only the first execution.
+ *
+ * This implementation won't close the OutputStream it delegates and leave the lifecycle management to its caller.
+ * You are not supposed to use this class in other occasions, but if you want to use it please remember to close the target OutputStream properly.
+ *
+ */
 public class DelegateOutputStream extends OutputStream {
 
     private OutputStream targetOutput;
-
 
     public DelegateOutputStream(OutputStream targetOutput) {
         this.targetOutput = targetOutput;
@@ -14,6 +23,7 @@ public class DelegateOutputStream extends OutputStream {
 
     @Override
     public void write(int b) throws IOException {
+        if(this.targetOutput == null) throw new IOException("Delegated OutputStream has been closed.");
         this.targetOutput.write(b);
     }
 
@@ -25,7 +35,8 @@ public class DelegateOutputStream extends OutputStream {
 
     @Override
     public void close() throws IOException {
-        this.targetOutput = null;   // Don't close the target OutputStream but dereference to it.
+        // Don't close the target OutputStream but dereference to it.
+        this.targetOutput = null;
         super.close();
     }
 }

--- a/src/main/java/com/plugin/sshjplugin/util/DelegateOutputStream.java
+++ b/src/main/java/com/plugin/sshjplugin/util/DelegateOutputStream.java
@@ -1,0 +1,31 @@
+package com.plugin.sshjplugin.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class DelegateOutputStream extends OutputStream {
+
+    private OutputStream targetOutput;
+
+
+    public DelegateOutputStream(OutputStream targetOutput) {
+        this.targetOutput = targetOutput;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        this.targetOutput.write(b);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        this.targetOutput.flush();
+        super.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.targetOutput = null;   // Don't close the target OutputStream but dereference to it.
+        super.close();
+    }
+}

--- a/src/test/groovy/com/plugin/sshjplugin/util/DelegateOutputStreamSpec.groovy
+++ b/src/test/groovy/com/plugin/sshjplugin/util/DelegateOutputStreamSpec.groovy
@@ -1,0 +1,39 @@
+package com.plugin.sshjplugin.util
+
+import spock.lang.Specification
+
+class DelegateOutputStreamSpec extends Specification {
+    def "When Delegate OutputStream closed it should not close the target OutputStream"() {
+        given:
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream()
+        DelegateOutputStream outputStream = new DelegateOutputStream(bytes)
+        Boolean isStreamClosed = false
+
+        String str1 = "This is a string"
+        String str2 = "This is another string"
+        String str3 = "This string should be write to the ByteArrayOutputStream"
+
+        when:
+        try {
+            outputStream.write(str1.getBytes("UTF-8"))
+        } finally {
+            outputStream.close()
+        }
+
+        try {
+            outputStream.write(str2.getBytes("UTF-8"))
+        } catch(IOException e) {
+            isStreamClosed = e.getMessage() == "Delegated OutputStream has been closed."
+        }
+
+        try {
+            bytes.write(str3.getBytes("UTF-8"))
+        } finally {
+            bytes.close()
+        }
+
+        then:
+        isStreamClosed == true
+        bytes.toString() == str1 + str3
+    }
+}


### PR DESCRIPTION
The problem is caused by an sshj lib change since version 0.33.0:

The StreamCopier closes the target output stream if it reaches the end of the input stream. This behavior will cause the `System.out` to close after one execution.

To solve this issue, we use a DelegateOutputStream to wrap the real System.out OutputStream, when the DelegateOutputStream was closed it won't close the target OutputStream it represented.


