### PR TITLE
Rse 765 file system keys unreachable in rundeck

### DIFF
--- a/src/main/java/com/plugin/sshjplugin/model/SSHJAuthentication.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJAuthentication.java
@@ -46,6 +46,15 @@ public class SSHJAuthentication {
                         throw new SSHJBuilder.BuilderException("Failed to read SSH Passphrase stored at path: " + passphrasePath);
                     }
                 }
+                if(privateKeyFileSystemPath!=null){
+                    logger.log(3, "[sshj-debug] Using SSH Keyfile: " + privateKeyFileSystemPath);
+                    if (passphrase == null) {
+                        keys = (FileKeyProvider) ssh.loadKeys(privateKeyFileSystemPath);
+                    } else {
+                        keys = (FileKeyProvider) ssh.loadKeys(privateKeyFileSystemPath, passphrase);
+                        logger.log(3, "[sshj-debug] Using Passphrase: " + passphrasePath);
+                    }
+                }
                 if(privateKeyStoragePath!=null){
                     logger.log(3, "[sshj-debug] Using SSH Storage key: " + privateKeyStoragePath);
                     try{
@@ -60,15 +69,6 @@ public class SSHJAuthentication {
                     } else {
                         logger.log(3, "[sshj-debug] Using Passphrase: " + passphrasePath);
                         keys.init(new StringReader(privateKeyContent), PasswordUtils.createOneOff(passphrase.toCharArray()));
-                    }
-                }
-                if(privateKeyFileSystemPath!=null){
-                    logger.log(3, "[sshj-debug] Using SSH Keyfile: " + privateKeyFileSystemPath);
-                    if (passphrase == null) {
-                        keys = (FileKeyProvider) ssh.loadKeys(privateKeyFileSystemPath);
-                    } else {
-                        keys = (FileKeyProvider) ssh.loadKeys(privateKeyFileSystemPath, passphrase);
-                        logger.log(3, "[sshj-debug] Using Passphrase: " + passphrasePath);
                     }
                 }
                 ssh.authPublickey(username, keys);

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJAuthentication.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJAuthentication.java
@@ -1,6 +1,5 @@
 package com.plugin.sshjplugin.model;
 import com.dtolabs.rundeck.plugins.PluginLogger;
-import com.dtolabs.utils.Streams;
 import com.plugin.sshjplugin.SSHJBuilder;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.common.Factory;
@@ -64,11 +63,14 @@ public class SSHJAuthentication {
                     }
                     KeyFormat format = KeyProviderUtil.detectKeyFileFormat(privateKeyContent,true);
                     keys = Factory.Named.Util.create(ssh.getTransport().getConfig().getFileKeyProviderFactories(), format.toString());
-                    if (passphrase == null) {
-                        keys.init(new StringReader(privateKeyContent), null);
-                    } else {
-                        logger.log(3, "[sshj-debug] Using Passphrase: " + passphrasePath);
-                        keys.init(new StringReader(privateKeyContent), PasswordUtils.createOneOff(passphrase.toCharArray()));
+
+                    if(keys != null ){
+                        if (passphrase == null) {
+                            keys.init(new StringReader(privateKeyContent), null);
+                        } else {
+                            logger.log(3, "[sshj-debug] Using Passphrase: " + passphrasePath);
+                            keys.init(new StringReader(privateKeyContent), PasswordUtils.createOneOff(passphrase.toCharArray()));
+                        }
                     }
                 }
                 ssh.authPublickey(username, keys);

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJAuthentication.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJAuthentication.java
@@ -39,14 +39,14 @@ public class SSHJAuthentication {
                 String passphrasePath = connectionParameters.getPrivateKeyPassphraseStoragePath();
                 FileKeyProvider keys = null;
 
-                if(passphrasePath!=null){
+                if(passphrasePath != null){
                     try{
                         passphrase = connectionParameters.getPrivateKeyPassphrase(passphrasePath);
                     } catch (Exception e) {
                         throw new SSHJBuilder.BuilderException("Failed to read SSH Passphrase stored at path: " + passphrasePath);
                     }
                 }
-                if(privateKeyFileSystemPath!=null){
+                if(privateKeyFileSystemPath != null && privateKeyStoragePath == null){
                     logger.log(3, "[sshj-debug] Using SSH Keyfile: " + privateKeyFileSystemPath);
                     if (passphrase == null) {
                         keys = (FileKeyProvider) ssh.loadKeys(privateKeyFileSystemPath);
@@ -55,7 +55,7 @@ public class SSHJAuthentication {
                         logger.log(3, "[sshj-debug] Using Passphrase: " + passphrasePath);
                     }
                 }
-                if(privateKeyStoragePath!=null){
+                if(privateKeyStoragePath != null){
                     logger.log(3, "[sshj-debug] Using SSH Storage key: " + privateKeyStoragePath);
                     try{
                         privateKeyContent = connectionParameters.getPrivateKeyStorage(privateKeyStoragePath);
@@ -75,7 +75,7 @@ public class SSHJAuthentication {
                 break;
             case password:
                 String passwordPath = connectionParameters.getPasswordStoragePath();
-                if(passwordPath!=null){
+                if(passwordPath != null){
                     logger.log(3, "Authenticating using password: " + passwordPath);
                 }
                 try{

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJAuthentication.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJAuthentication.java
@@ -35,7 +35,7 @@ public class SSHJAuthentication {
             case privateKey:
                 logger.log(3, "Authenticating using private key");
                 String privateKeyStoragePath = connectionParameters.getPrivateKeyStoragePath();
-                String privateKeyFilePath = connectionParameters.getPrivateKeyFilePath();
+                String privateKeyFileSystemPath = connectionParameters.getPrivateKeyFilePath();
                 String passphrasePath = connectionParameters.getPrivateKeyPassphraseStoragePath();
                 FileKeyProvider keys = null;
 
@@ -62,12 +62,12 @@ public class SSHJAuthentication {
                         keys.init(new StringReader(privateKeyContent), PasswordUtils.createOneOff(passphrase.toCharArray()));
                     }
                 }
-                if(privateKeyFilePath!=null){
-                    logger.log(3, "[sshj-debug] Using SSH Keyfile: " + privateKeyFilePath);
+                if(privateKeyFileSystemPath!=null){
+                    logger.log(3, "[sshj-debug] Using SSH Keyfile: " + privateKeyFileSystemPath);
                     if (passphrase == null) {
-                        keys = (FileKeyProvider) ssh.loadKeys(privateKeyFilePath);
+                        keys = (FileKeyProvider) ssh.loadKeys(privateKeyFileSystemPath);
                     } else {
-                        keys = (FileKeyProvider) ssh.loadKeys(privateKeyFilePath, passphrase);
+                        keys = (FileKeyProvider) ssh.loadKeys(privateKeyFileSystemPath, passphrase);
                         logger.log(3, "[sshj-debug] Using Passphrase: " + passphrasePath);
                     }
                 }

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJConnection.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJConnection.java
@@ -25,6 +25,8 @@ public interface SSHJConnection{
 
     String getPasswordStoragePath();
 
+    String getPrivateKeyFilePath();
+
     String getPassword(String path) throws IOException;
 
     String getSudoPasswordStoragePath();

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJConnectionParameters.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJConnectionParameters.java
@@ -59,7 +59,7 @@ public class SSHJConnectionParameters implements SSHJConnection{
 
         }else{
 
-            privateKeyFile = getPrivateKeyfilePath();
+            privateKeyFile = getPrivateKeyFilePath();
             context.getExecutionListener().log(3, "[sshj-debug] Using ssh keyfile: " + privateKeyFile);
         }
 
@@ -96,7 +96,8 @@ public class SSHJConnectionParameters implements SSHJConnection{
         return propertyResolver.getPrivateKeyStorage(path);
     }
 
-    String getPrivateKeyfilePath() {
+    @Override
+    public String getPrivateKeyFilePath() {
         String path = propertyResolver.resolve(SSHJNodeExecutorPlugin.NODE_ATTR_SSH_KEYPATH);
         if (path == null && framework.hasProperty(Constants.SSH_KEYPATH_PROP)) {
             //return default framework level

--- a/src/test/groovy/com/plugin/sshjplugin/model/SSHJAuthenticationTest.groovy
+++ b/src/test/groovy/com/plugin/sshjplugin/model/SSHJAuthenticationTest.groovy
@@ -1,0 +1,114 @@
+package com.plugin.sshjplugin.model
+
+import com.dtolabs.rundeck.plugins.PluginLogger
+import com.hierynomus.sshj.userauth.keyprovider.OpenSSHKeyV1KeyFile
+import net.schmizz.sshj.Config
+import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.common.Factory
+import net.schmizz.sshj.transport.Transport
+import net.schmizz.sshj.userauth.keyprovider.FileKeyProvider
+import spock.lang.Specification
+import net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile;
+import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile;
+import net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
+
+
+class SSHJAuthenticationTest extends Specification {
+
+    def "authenticate with private key on filesystem no passphrase"() {
+        given:
+        SSHClient sshClient = Mock(SSHClient)
+        PluginLogger pluginLogger = Mock(PluginLogger)
+        SSHJConnection connectionParameters = Mock(SSHJConnection){
+            1 * getAuthenticationType() >> SSHJConnection.AuthenticationType.privateKey
+            1 * getPrivateKeyFilePath() >> "keys/rundeck/storage"
+            0 * getPrivateKeyPassphrase(_)
+            0 * getPrivateKeyStorage(_)
+        }
+
+        SSHJAuthentication auth = new SSHJAuthentication(connectionParameters,pluginLogger)
+
+        when:
+        auth.authenticate(sshClient)
+
+        then:
+        1 * sshClient.authPublickey(_, _)
+        1 * sshClient.loadKeys(_)
+        0 * sshClient.loadKeys(_, _)
+    }
+
+    def "authenticate with private key on filesystem with passphrase"() {
+        given:
+        String passphraseStoragePath = "keys/rundeck/storage/passphrase"
+
+        SSHClient sshClient = Mock(SSHClient)
+        PluginLogger pluginLogger = Mock(PluginLogger)
+        SSHJConnection connectionParameters = Mock(SSHJConnection){
+            1 * getAuthenticationType() >> SSHJConnection.AuthenticationType.privateKey
+            1 * getPrivateKeyFilePath() >> "keys/rundeck/storage"
+            1 * getPrivateKeyPassphraseStoragePath() >> passphraseStoragePath
+            1 * getPrivateKeyPassphrase(passphraseStoragePath) >> "pass"
+            0 * getPrivateKeyStorage(_)
+        }
+        SSHJAuthentication auth = new SSHJAuthentication(connectionParameters,pluginLogger)
+
+        when:
+        auth.authenticate(sshClient)
+
+        then:
+        0 * sshClient.loadKeys(_)
+        1 * sshClient.authPublickey(_, _)
+    }
+
+
+
+   /* def "authenticate with private key Rundeck storage no passphrase"() {
+        given:
+        String keyStoragePath = "keys/rundeck/storage"
+        SSHClient sshClient = Mock(SSHClient){
+            getTransport() >> Mock(Transport){
+                getConfig() >> Mock(Config){
+                    getFileKeyProviderFactories() >> providerFactoriesList()
+                }
+            }
+        }
+        PluginLogger pluginLogger = Mock(PluginLogger)
+        SSHJConnection connectionParameters = Mock(SSHJConnection){
+            1 * getAuthenticationType() >> SSHJConnection.AuthenticationType.privateKey
+            1 * getPrivateKeyStoragePath() >> keyStoragePath
+            1 * getPrivateKeyStorage(keyStoragePath) >> "-----BEGIN OPENSSH PRIVATE KEY-----\n" +
+                    "b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABCBHpyIOm\n" +
+                    "Y45NDeuHxAzGCUAAAAEAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIKUYWSH2YrYUH3IA\n" +
+                    "t40IcM0ykM03oFRI7m+5jEK+fE4LAAAAoBIhOVxejwLYvIKIBgNQOe0j8h2nnz/+sEYUDc\n" +
+                    "ug6KrlPxQ7kuL67It/Tb7IxAGzVWT3g3fkQMGNU/8uxRHAf5fQC9aYValFPr21g7I39OqR\n" +
+                    "MbPXHnD8a+DwAw3ArakcZigzWqncuX5cuBgpr5+x/iXWAz0lAHJH1d5HaIsoy1K6VmMR+b\n" +
+                    "GN7ixrjWwMVBM+Lv8DdRN5UnniX5grj6M8P0A=\n" +
+                    "-----END OPENSSH PRIVATE KEY-----"
+            0 * getPrivateKeyPassphrase(_)
+            0 * getPrivateKeyStorage(_)
+        }
+
+        SSHJAuthentication auth = new SSHJAuthentication(connectionParameters,pluginLogger)
+        OpenSSHKeyV1KeyFile
+
+        when:
+        auth.authenticate(sshClient)
+
+        then:
+        true
+    }*/
+
+
+    public static List <Factory.Named<FileKeyProvider>> providerFactoriesList() {
+        List<Factory.Named<FileKeyProvider>> factories = new ArrayList<>();
+        factories.add(OpenSSHKeyV1KeyFile);
+        factories.add(PKCS8KeyFile);
+        factories.add(OpenSSHKeyFile);
+        factories.add(PuTTYKeyFile);
+
+        return factories;
+    }
+
+
+    }
+

--- a/src/test/groovy/com/plugin/sshjplugin/model/SSHJAuthenticationTest.groovy
+++ b/src/test/groovy/com/plugin/sshjplugin/model/SSHJAuthenticationTest.groovy
@@ -8,9 +8,6 @@ import net.schmizz.sshj.common.Factory
 import net.schmizz.sshj.transport.Transport
 import net.schmizz.sshj.userauth.keyprovider.FileKeyProvider
 import spock.lang.Specification
-import net.schmizz.sshj.userauth.keyprovider.PKCS8KeyFile;
-import net.schmizz.sshj.userauth.keyprovider.OpenSSHKeyFile;
-import net.schmizz.sshj.userauth.keyprovider.PuTTYKeyFile
 
 
 class SSHJAuthenticationTest extends Specification {
@@ -62,7 +59,7 @@ class SSHJAuthenticationTest extends Specification {
 
 
 
-   /* def "authenticate with private key Rundeck storage no passphrase"() {
+    def "authenticate with private key Rundeck storage no passphrase"() {
         given:
         String keyStoragePath = "keys/rundeck/storage"
         SSHClient sshClient = Mock(SSHClient){
@@ -96,17 +93,21 @@ class SSHJAuthenticationTest extends Specification {
 
         then:
         true
-    }*/
+    }
 
-
-    public static List <Factory.Named<FileKeyProvider>> providerFactoriesList() {
-        List<Factory.Named<FileKeyProvider>> factories = new ArrayList<>();
-        factories.add(OpenSSHKeyV1KeyFile);
-        factories.add(PKCS8KeyFile);
-        factories.add(OpenSSHKeyFile);
-        factories.add(PuTTYKeyFile);
-
-        return factories;
+    private static List<Factory.Named<FileKeyProvider>> providerFactoriesList() {
+        List<Factory.Named<FileKeyProvider>> namedList = new ArrayList<>();
+        namedList.add(new Factory.Named<FileKeyProvider>(){
+            @Override
+            FileKeyProvider create() {
+                return new OpenSSHKeyV1KeyFile();
+            }
+            @Override
+            String getName() {
+                return "OpenSSHKeyV1KeyFile"
+            }
+        })
+        return namedList;
     }
 
 


### PR DESCRIPTION
Problem: A in the sshj-plugin has modified how private keys are used by the SSHClient, as a consequence of this change, private keys stored in the filesystem have become inaccessible to Rundeck, resulting in failed node authentication.

Solution
The auth method  was adapted to take in count the location of the key. If the private key is stored in Rundeck (AKA key storage), the current behavior will remain the same to avoid generating a temporary key. If the private key is located at a filesystem path, it will be loaded into the SSHClient, allowing it to authenticate again.