### PR TITLE
RPL-40: add pty option

### DIFF
--- a/src/main/java/com/plugin/sshjplugin/SSHJBuilder.java
+++ b/src/main/java/com/plugin/sshjplugin/SSHJBuilder.java
@@ -22,7 +22,7 @@ public class SSHJBuilder {
         SSHJExec sshbase = new SSHJExec();
         final String commandString = StringUtils.join(args, " ");
         sshbase.setCommand(commandString);
-
+        sshbase.setAllowPTY(sshjConnectionParameters.isAllocatePTY());
         configureSSHBase(nodeentry, sshjConnectionParameters, sshbase, logger);
         addEnvVars(sshbase, dataContext);
 

--- a/src/main/java/com/plugin/sshjplugin/SSHJNodeExecutorPlugin.java
+++ b/src/main/java/com/plugin/sshjplugin/SSHJNodeExecutorPlugin.java
@@ -188,7 +188,7 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, ProxySecretBundleCr
             false, "false");
 
     public static final Property ALWAYS_SET_PTY = PropertyUtil.bool(CONFIG_SET_PTY, "Force PTY",
-            "Always force use of new pty, enabling this option will suppress some logging",
+            "Always force use of new pty",
             false, "false");
 
     private SSHClient sshClient;

--- a/src/main/java/com/plugin/sshjplugin/SSHJNodeExecutorPlugin.java
+++ b/src/main/java/com/plugin/sshjplugin/SSHJNodeExecutorPlugin.java
@@ -78,6 +78,7 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, ProxySecretBundleCr
     public static final String NODE_ATTR_USE_SFTP = "use-sftp";
 
     public static final String PROJECT_SSH_USER = PROJ_PROP_PREFIX + "ssh.user";
+    public static final String CONFIG_SET_PTY = "always-set-pty";
 
     public static final String FWK_PROP_SSH_AUTHENTICATION = FWK_PROP_PREFIX + NODE_ATTR_SSH_AUTHENTICATION;
     public static final String PROJ_PROP_SSH_AUTHENTICATION = PROJ_PROP_PREFIX + NODE_ATTR_SSH_AUTHENTICATION;
@@ -104,6 +105,10 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, ProxySecretBundleCr
 
     public static final String FWK_PROP_USE_SFTP = FWK_PROP_PREFIX + NODE_ATTR_USE_SFTP;
     public static final String PROJ_PROP_USE_SFTP = PROJ_PROP_PREFIX + NODE_ATTR_USE_SFTP;
+
+    public static final String NODE_ATTR_ALWAYS_SET_PTY = "always-set-pty";
+    public static final String FWK_PROP_SET_PTY = FWK_PROP_PREFIX + NODE_ATTR_ALWAYS_SET_PTY;
+    public static final String PROJ_PROP_SET_PTY = PROJ_PROP_PREFIX + NODE_ATTR_ALWAYS_SET_PTY;
 
     public static final String SUDO_OPT_PREFIX = "sudo-";
 
@@ -182,6 +187,10 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, ProxySecretBundleCr
             "Use SFTP for file transfer",
             false, "false");
 
+    public static final Property ALWAYS_SET_PTY = PropertyUtil.bool(CONFIG_SET_PTY, "Force PTY",
+            "Always force use of new pty, enabling this option will suppress some logging",
+            false, "false");
+
     private SSHClient sshClient;
 
     public void setSshClient(SSHClient sshClient) {
@@ -210,6 +219,7 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, ProxySecretBundleCr
         builder.property(SSH_KEEP_ALIVE_MAX_ALIVE_COUNT);
         builder.property(SSH_RETRY_ENABLE);
         builder.property(SSH_RETRY_COUNTER);
+        builder.property(ALWAYS_SET_PTY);
 
         //mapping config input on project and framework level
         builder.mapping(CONFIG_KEYPATH, PROJ_PROP_SSH_KEYPATH);
@@ -233,6 +243,9 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, ProxySecretBundleCr
         builder.mapping(CONFIG_RETRY_ENABLE, PROJ_PROP_RETRY_ENABLE);
         builder.frameworkMapping(CONFIG_RETRY_ENABLE, FWK_PROP_RETRY_ENABLE);
 
+        builder.mapping(CONFIG_SET_PTY, PROJ_PROP_SET_PTY);
+        builder.frameworkMapping(CONFIG_SET_PTY, FWK_PROP_SET_PTY);
+
         return builder.build();
     }
 
@@ -246,6 +259,7 @@ public class SSHJNodeExecutorPlugin implements NodeExecutor, ProxySecretBundleCr
                     node
             );
         }
+
         boolean success = false;
 
         final ExecutionListener listener = context.getExecutionListener();

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJConnection.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJConnection.java
@@ -66,4 +66,7 @@ public interface SSHJConnection{
     Map<String, String> getSshConfig();
 
     String getBindAddress();
+
+    boolean isAllocatePTY();
+
 }

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJConnectionParameters.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJConnectionParameters.java
@@ -297,7 +297,10 @@ public class SSHJConnectionParameters implements SSHJConnection{
     public String getBindAddress() {
         return null;
     }
-
+    @Override
+    public boolean isAllocatePTY() {
+        return propertyResolver.resolveBoolean(SSHJNodeExecutorPlugin.CONFIG_SET_PTY);
+    }
 
 
 

--- a/src/main/java/com/plugin/sshjplugin/model/SSHJExec.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJExec.java
@@ -24,9 +24,14 @@ public class SSHJExec extends SSHJBase implements SSHJEnvironments {
     private String command = null;
     private int exitStatus = -1;
     private Map<String, String> envVars = null;
+    private boolean allowPTY = false;
 
     public void setCommand(String command) {
         this.command = command;
+    }
+
+    public void setAllowPTY(boolean allowPTY){
+        this.allowPTY = allowPTY;
     }
 
     public void setPluginLogger(PluginLogger pluginLogger) {
@@ -53,6 +58,9 @@ public class SSHJExec extends SSHJBase implements SSHJEnvironments {
             pluginLogger.log(3, "["+getPluginName()+"]  starting session" );
 
             session = ssh.startSession();
+            if(this.allowPTY){
+                session.allocateDefaultPTY();
+            }
 
             pluginLogger.log(3, "["+getPluginName()+"] setting environments" );
 


### PR DESCRIPTION
This provides the option to allow PTY allocation, providing capability to perform sudo with password asking prompt

How to test:

1. Select PTY option enabled in node executor config
2. Setup a remote node with sudo command enabled with the following attributes
```
ssh-password-option: option.sshPassword
sudo-password-option: option.sudoPassword
ssh-authentication: password
sudo-command-enabled: 'true'
```
3. Create a job that runs a sudo command against the node
4. The execution should be performed and not get stuck when asking for the sudo password

Functional tests will be added to rundeck OSS