### PR TITLE
RUN-2731: Fixes rundeck/rundeck#9221

### DIFF
--- a/src/main/java/com/plugin/sshjplugin/model/SSHJScp.java
+++ b/src/main/java/com/plugin/sshjplugin/model/SSHJScp.java
@@ -83,9 +83,9 @@ public class SSHJScp extends SSHJBase {
                     try {
 
                         if(useSftp) {
-                            sftp.put(new FileSystemFile(this.localFile), toDir);
+                            sftp.put(new FileSystemFile(file), toDir);
                         } else {
-                            ssh.newSCPFileTransfer().upload(new FileSystemFile(this.localFile), toDir);
+                            ssh.newSCPFileTransfer().upload(new FileSystemFile(file), toDir);
                         }
                     } catch (IOException e) {
                         e.printStackTrace();


### PR DESCRIPTION
The issue is caused by using the invalid this.localFile instead of the files in this.fileSets.

The issue was introduced by commit 222dc1d