### PR TITLE
RUN-3592: Modernize build configuration and update GitHub workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,11 +25,11 @@ jobs:
         run: ./gradlew build
       - name: Get Release Version
         id: get_version
-        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
-      - name: Upload sshj-plugin jar
+        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+      - name: Upload artifact jar
         uses: actions/upload-artifact@v4
         with:
           # Artifact name
-          name: Grails-Plugin-${{ steps.get_version.outputs.VERSION }}
+          name: SSHJ-Plugin-${{ steps.get_version.outputs.VERSION }}
           # Directory containing files to upload
-          path: build/libs/sshj-plugin-${{ steps.get_version.outputs.VERSION }}.jar
+          path: build/libs/*-${{ steps.get_version.outputs.VERSION }}.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,20 +2,20 @@ on:
   push:
     # Sequence of patterns matched against refs/tags
     tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+      - 'v[0-9]+.[0-9]+.[0-9]+' # Push events to matching v*, i.e. v1.0, v20.15.10
 
-name: Upload Release Asset
+name: Publish Release
 
 jobs:
   build:
-    name: Upload Release Asset
+    name: Publish Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: set up JDK 11
+      - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           java-version: '11'
@@ -24,24 +24,21 @@ jobs:
         run: ./gradlew build
       - name: Get Release Version
         id: get_version
-        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo ::set-output name=VERSION::$VERSION
+        run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1.1.4
+        run: |
+          gh release create \
+            --generate-notes \
+            --title 'Release ${{ steps.get_version.outputs.VERSION }}' \
+            ${{ github.ref_name }} \
+            build/libs/sshj-plugin-${{ steps.get_version.outputs.VERSION }}.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ steps.get_version.outputs.VERSION }}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset (jar)
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+      - name: Publish to Maven Central
+        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: build/libs/sshj-plugin-${{ steps.get_version.outputs.VERSION }}.jar
-          asset_name: sshj-plugin-${{ steps.get_version.outputs.VERSION }}.jar
-          asset_content_type: application/octet-stream
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -97,7 +97,10 @@ jar.dependsOn(copyToLib)
 nexusPublishing {
     packageGroup = 'org.rundeck.plugins'
     repositories {
-        sonatype()
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,24 +1,21 @@
 plugins {
-    alias(libs.plugins.axionRelease)
     id 'java'
-    id 'maven-publish'
+    id 'groovy'
+    id 'idea'
+    alias(libs.plugins.axionRelease)
+    alias(libs.plugins.nexusPublish)
 }
 
-defaultTasks 'clean','build'
-apply plugin: 'java'
-apply plugin: 'groovy'
-apply plugin: 'idea'
-
-ext.rundeckPluginVersion= '1.2'
-ext.rundeckVersion= '3.3.x'
+group = 'org.rundeck.plugins'
 ext.pluginClassNames='com.plugin.sshjplugin.SSHJNodeExecutorPlugin,com.plugin.sshjplugin.SSHJFileCopierPlugin'
 ext.pluginName = 'SSHJ Plugin'
-ext.pluginDescription ='SSH Node Executor and File Copier plugin based on SSHJ library.'
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
+ext.pluginDescription = 'SSH Node Executor and File Copier plugin based on SSHJ library.'
+ext.rundeckPluginVersion= '1.2'
+ext.publishName = "SSHJ Plugin ${project.version}"
+ext.githubSlug = 'rundeck-plugins/sshj-plugin'
+ext.developers = [
+        [id: 'gschueler', name: 'Greg Schueler', email: 'greg@rundeck.com']
+]
 
 scmVersion {
     ignoreUncommittedChanges = true
@@ -28,7 +25,12 @@ scmVersion {
     }
 }
 
-project.version = scmVersion.version
+allprojects {
+    project.version = scmVersion.version
+    apply from: "${rootDir}/gradle/java.gradle"
+}
+
+defaultTasks 'clean','build'
 
 repositories {
     mavenLocal()
@@ -75,25 +77,28 @@ jar {
         attributes 'Rundeck-Plugin-Rundeck-Compatibility-Version': '2.x+'
         attributes 'Rundeck-Plugin-Tags': 'java,executor'
         attributes 'Rundeck-Plugin-License': 'MIT'
-        attributes 'Rundeck-Plugin-Source-Link': 'https://github.com/rundeck-plugins'
+        attributes 'Rundeck-Plugin-Source-Link': 'https://github.com/rundeck-plugins/sshj-plugin'
         attributes 'Rundeck-Plugin-Target-Host-Compatibility': 'all'
         attributes 'Rundeck-Plugin-Author': 'Rundeck, Inc.'
         attributes 'Rundeck-Plugin-Classnames': pluginClassNames
-        attributes 'Rundeck-Plugin-File-Version': version
+        attributes 'Rundeck-Plugin-File-Version': project.version
         attributes 'Rundeck-Plugin-Version': rundeckPluginVersion, 'Rundeck-Plugin-Archive': 'true'
         attributes 'Rundeck-Plugin-Libs': "${libList}"
-        attributes 'Class-Path': "${libList} lib/rundeck-core-${rundeckVersion}.jar"
     }
 }
+
+test {
+    useJUnitPlatform()
+}
+
 //set jar task to depend on copyToLib
 jar.dependsOn(copyToLib)
 
-
-publishing {
-    publications {
-        maven(MavenPublication) {
-            artifactId = 'jq-json-logfilter'
-            from components.java
-        }
+nexusPublishing {
+    packageGroup = 'org.rundeck.plugins'
+    repositories {
+        sonatype()
     }
 }
+
+apply from: "${rootDir}/gradle/publishing.gradle"

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -1,0 +1,13 @@
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    withJavadocJar()
+    withSourcesJar()
+}
+
+allprojects {
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile).configureEach {
+            options.compilerArgs.add("-Xlint:deprecation")
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,8 @@ groovy = "3.0.22"
 spock = "2.0-groovy-3.0"
 cglib = "3.3.0"
 objenesis = "1.4"
-axionRelease = "1.18.14"
+axionRelease = "1.18.18"
+nexusPublish = "2.0.0"
 
 [libraries]
 sshj = { group = "com.hierynomus", name = "sshj", version.ref = "sshj" }
@@ -36,3 +37,4 @@ testLibs = ["junit", "groovyAll", "spockCore", "cglibNodep", "objenesis"]
 
 [plugins]
 axionRelease = { id = "pl.allegro.tech.build.axion-release", version.ref = "axionRelease" }
+nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,0 +1,70 @@
+/**
+ * Define project extension values in the project gradle file before including this file:
+ *
+ * publishName = 'Name of Package'
+ * publishDescription = 'description' (optional)
+ * githubSlug = Github slug e.g. 'rundeck/rundeck-cli'
+ * developers = [ [id:'id', name:'name', email: 'email' ] ] list of developers
+ *
+ * Define project properties to sign and publish when invoking publish task:
+ *
+ *     ./gradlew \
+ *     -PsigningKey="base64 encoded gpg key" \
+ *     -PsigningPassword="password for key" \
+ *     -PsonatypeUsername="sonatype token user" \
+ *     -PsonatypePassword="sonatype token password" \
+ *     publishToSonatype closeAndReleaseSonatypeStagingRepository
+ */
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+publishing {
+    publications {
+        "${project.name}"(MavenPublication) { publication ->
+            from components.java
+
+            pom {
+                name = publishName
+                description = project.ext.hasProperty('pluginDescription') ? project.ext.pluginDescription :
+                        project.description ?: publishName
+                url = "https://github.com/${githubSlug}"
+                licenses {
+                    license {
+                        name = 'The Apache Software License, Version 2.0'
+                        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
+                    }
+                }
+                scm {
+                    url = "https://github.com/${githubSlug}"
+                    connection = "scm:git:git@github.com/${githubSlug}.git"
+                    developerConnection = "scm:git:git@github.com:${githubSlug}.git"
+                }
+                if (project.ext.developers) {
+                    developers {
+                        project.ext.developers.each { dev ->
+                            developer {
+                                id = dev.id
+                                name = dev.name
+                                email = dev.email
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+    }
+}
+def base64Decode = { String prop ->
+    project.findProperty(prop) ?
+            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
+            null
+}
+
+if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
+    signing {
+        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
+        sign(publishing.publications)
+    }
+}


### PR DESCRIPTION
- Updated version catalog with additional plugins
- Updated build.gradle to use nexusPublish plugin
- Added java.gradle for Java 11 compatibility
- Added publishing.gradle for Maven Central publishing
- Updated GitHub workflows for building and releasing
- Use org.rundeck.plugins as Maven groupId