### PR TITLE
RUN-3628: Address CVE-2023-45857 by adding an override for axios

### DIFF
--- a/docker/client/rundeck-cli/package.json
+++ b/docker/client/rundeck-cli/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "@types/node-fetch": "^2.5.7",
     "@types/yargs": "^15.0.4"
+  },
+  "overrides": {
+    "axios": "1.11.0"
   }
 }


### PR DESCRIPTION
As we cannot update ts-rundeck, adding an override for axios. 

Logs after running `npm install` and `npm ls --depth=2`:

```
├── @types/js-yaml@3.12.10
├─┬ @types/node-fetch@2.6.13
│ ├── @types/node@13.13.52 deduped
│ └─┬ form-data@4.0.4
│   ├── asynckit@0.4.0 deduped
│   ├── combined-stream@1.0.8 deduped
│   ├── es-set-tostringtag@2.1.0 deduped
│   ├── hasown@2.0.2 deduped
│   └── mime-types@2.1.35 deduped
├── @types/node@13.13.52
├─┬ @types/yargs@15.0.19
│ └── @types/yargs-parser@21.0.3
├── dotenv@10.0.0
├─┬ form-data@3.0.4
│ ├── asynckit@0.4.0
│ ├─┬ combined-stream@1.0.8
│ │ └── delayed-stream@1.0.0
│ ├─┬ es-set-tostringtag@2.1.0
│ │ ├── es-errors@1.3.0
│ │ ├── get-intrinsic@1.3.0
│ │ ├── has-tostringtag@1.0.2
│ │ └── hasown@2.0.2 deduped
│ ├─┬ hasown@2.0.2
│ │ └── function-bind@1.1.2
│ └─┬ mime-types@2.1.35
│   └── mime-db@1.52.0
├─┬ js-yaml@3.14.1
│ ├─┬ argparse@1.0.10
│ │ └── sprintf-js@1.0.3
│ └── esprima@4.0.1
├─┬ node-fetch@2.7.0
│ ├── UNMET OPTIONAL DEPENDENCY encoding@^0.1.0
│ └─┬ whatwg-url@5.0.0
│   ├── tr46@0.0.3
│   └── webidl-conversions@3.0.1
├─┬ ts-node@8.10.2
│ ├── arg@4.1.3
│ ├── diff@4.0.2
│ ├── make-error@1.3.6
│ ├─┬ source-map-support@0.5.21
│ │ ├── buffer-from@1.1.2
│ │ └── source-map@0.6.1
│ ├── typescript@3.9.10 deduped
│ └── yn@3.1.1
├─┬ ts-rundeck@0.1.9
│ ├─┬ @azure/ms-rest-js@1.7.0
│ │ ├── @types/tunnel@0.0.0
│ │ ├── axios@1.11.0 deduped
│ │ ├── form-data@2.5.5
│ │ ├── tough-cookie@2.5.0
│ │ ├── tslib@1.14.1
│ │ ├── tunnel@0.0.6
│ │ ├── uuid@3.4.0
│ │ └── xml2js@0.4.23
│ ├── @types/promise-queue@2.2.3
│ ├─┬ axios@1.11.0 overridden
│ │ ├── follow-redirects@1.15.11
│ │ ├── form-data@4.0.4
│ │ └── proxy-from-env@1.1.0
│ └── promise-queue@2.2.5
├─┬ tsconfig-paths@3.15.0
│ ├── @types/json5@0.0.29
│ ├─┬ json5@1.0.2
│ │ └── minimist@1.2.8 deduped
│ ├── minimist@1.2.8
│ └── strip-bom@3.0.0
├── typescript@3.9.10
├── yaml@1.10.2
└─┬ yargs@15.4.1
  ├─┬ cliui@6.0.0
  │ ├── string-width@4.2.3 deduped
  │ ├── strip-ansi@6.0.1
  │ └── wrap-ansi@6.2.0
  ├── decamelize@1.2.0
  ├─┬ find-up@4.1.0
  │ ├── locate-path@5.0.0
  │ └── path-exists@4.0.0
  ├── get-caller-file@2.0.5
  ├── require-directory@2.1.1
  ├── require-main-filename@2.0.0
  ├── set-blocking@2.0.0
  ├─┬ string-width@4.2.3
  │ ├── emoji-regex@8.0.0
  │ ├── is-fullwidth-code-point@3.0.0
  │ └── strip-ansi@6.0.1 deduped
  ├── which-module@2.0.1
  ├── y18n@4.0.3
  └─┬ yargs-parser@18.1.3
    ├── camelcase@5.3.1
    └── decamelize@1.2.0 deduped
    ```