### PR TITLE
[RUN-4638] Migrate publishing from Maven Central to PackageCloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PackageCloud
-        run: ./gradlew publishAllPublicationsToPackageCloudRepository
+        run: |
+          if [ -z "$PKGCLD_REPO_URL" ] || [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_REPO_URL and PKGCLD_WRITE_TOKEN must both be set to publish to PackageCloud"
+            exit 1
+          fi
+          ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PackageCloud
         run: |
-          if [ -z "$PKGCLD_REPO_URL" ] || [ -z "$PKGCLD_WRITE_TOKEN" ]; then
-            echo "::error::PKGCLD_REPO_URL and PKGCLD_WRITE_TOKEN must both be set to publish to PackageCloud"
+          if [ -z "$PKGCLD_WRITE_TOKEN" ]; then
+            echo "::error::PKGCLD_WRITE_TOKEN must be set to publish to PackageCloud"
             exit 1
           fi
           ./gradlew publishAllPublicationsToPackageCloudRepository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,7 @@ jobs:
             build/libs/sshj-plugin-${{ steps.get_version.outputs.VERSION }}.jar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish to Maven Central
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} -PsonatypeUsername=${SONATYPE_USERNAME} -PsonatypePassword=${SONATYPE_PASSWORD} publishToSonatype closeAndReleaseSonatypeStagingRepository
+      - name: Publish to PackageCloud
+        run: ./gradlew publishAllPublicationsToPackageCloudTestRepository
         env:
-          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PackageCloud
-        run: ./gradlew publishAllPublicationsToPackageCloudTestRepository
+        run: ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+          PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,12 @@ jobs:
           BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck-plugins/maven2}/org/rundeck/plugins/sshj-plugin/${VERSION}"
 
           echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec/ {print $5; exit}')
 
           sign_and_upload() {
             local FILE="$1"
             local REMOTE_NAME="$2"
-            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --detach-sign --armor "$FILE"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --default-key "$KEY_ID" --detach-sign --armor "$FILE"
             curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
               -X PUT --data-binary "@${FILE}.asc" \
               "${BASE_URL}/${REMOTE_NAME}.asc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PackageCloud
-        run: ./gradlew publishAllPublicationsToPackageCloudRepository
+        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
           PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
+          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,28 @@ jobs:
           ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
+      - name: Sign and upload GPG signatures to PackageCloud
+        run: |
+          set -e
+          VERSION="${{ steps.get_version.outputs.VERSION }}"
+          BASE_URL="${PKGCLD_REPO_URL:-https://packagecloud.io/pagerduty/rundeck-plugins/maven2}/org/rundeck/plugins/sshj-plugin/${VERSION}"
+
+          echo "$SIGNING_KEY_B64" | base64 -d | gpg --batch --yes --import
+
+          sign_and_upload() {
+            local FILE="$1"
+            local REMOTE_NAME="$2"
+            gpg --batch --yes --pinentry-mode loopback --passphrase "$SIGNING_PASSWORD" --detach-sign --armor "$FILE"
+            curl -sf -H "Authorization: Bearer ${PKGCLD_WRITE_TOKEN}" \
+              -X PUT --data-binary "@${FILE}.asc" \
+              "${BASE_URL}/${REMOTE_NAME}.asc"
+          }
+
+          sign_and_upload "build/libs/sshj-plugin-${VERSION}.jar" "sshj-plugin-${VERSION}.jar"
+          sign_and_upload "build/libs/sshj-plugin-${VERSION}-sources.jar" "sshj-plugin-${VERSION}-sources.jar"
+          sign_and_upload "build/libs/sshj-plugin-${VERSION}-javadoc.jar" "sshj-plugin-${VERSION}-javadoc.jar"
+          sign_and_upload "build/publications/sshj-plugin/pom-default.xml" "sshj-plugin-${VERSION}.pom"
+        env:
+          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   build:
     name: Publish Release
     runs-on: ubuntu-latest
+    env:
+      PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -39,6 +41,5 @@ jobs:
         run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
-          PKGCLD_REPO_URL: ${{ vars.PKGCLD_REPO_URL }}
           SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish to PackageCloud
-        run: ./gradlew -PsigningKey=${SIGNING_KEY_B64} -PsigningPassword=${SIGNING_PASSWORD} publishAllPublicationsToPackageCloudRepository
+        run: ./gradlew publishAllPublicationsToPackageCloudRepository
         env:
           PKGCLD_WRITE_TOKEN: ${{ secrets.PKGCLD_WRITE_TOKEN }}
-          SIGNING_KEY_B64: ${{ secrets.SIGNING_KEY_B64 }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -125,14 +125,16 @@ jar.dependsOn(copyToLib)
 
 apply from: "${rootDir}/gradle/publishing.gradle"
 
+def pkgcldRepoUrl = System.getenv("PKGCLD_REPO_URL")?.trim()
+
 publishing {
     repositories {
         // Only register the PackageCloud repo when its URL is configured, so plain
         // builds/tests (which don't set PKGCLD_REPO_URL) don't fail at configuration time.
-        if (System.getenv("PKGCLD_REPO_URL")) {
+        if (pkgcldRepoUrl) {
             maven {
                 name = "PackageCloud"
-                url = uri(System.getenv("PKGCLD_REPO_URL"))
+                url = uri(pkgcldRepoUrl)
                 authentication {
                     header(HttpHeaderAuthentication)
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -127,15 +127,19 @@ apply from: "${rootDir}/gradle/publishing.gradle"
 
 publishing {
     repositories {
-        maven {
-            name = "PackageCloud"
-            url = uri(System.getenv("PKGCLD_REPO_URL"))
-            authentication {
-                header(HttpHeaderAuthentication)
-            }
-            credentials(HttpHeaderCredentials) {
-                name = "Authorization"
-                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
+        // Only register the PackageCloud repo when its URL is configured, so plain
+        // builds/tests (which don't set PKGCLD_REPO_URL) don't fail at configuration time.
+        if (System.getenv("PKGCLD_REPO_URL")) {
+            maven {
+                name = "PackageCloud"
+                url = uri(System.getenv("PKGCLD_REPO_URL"))
+                authentication {
+                    header(HttpHeaderAuthentication)
+                }
+                credentials(HttpHeaderCredentials) {
+                    name = "Authorization"
+                    value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -125,23 +125,19 @@ jar.dependsOn(copyToLib)
 
 apply from: "${rootDir}/gradle/publishing.gradle"
 
-def pkgcldRepoUrl = System.getenv("PKGCLD_REPO_URL")?.trim()
+def pkgcldRepoUrl = (System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeck-plugins/maven2").trim()
 
 publishing {
     repositories {
-        // Only register the PackageCloud repo when its URL is configured, so plain
-        // builds/tests (which don't set PKGCLD_REPO_URL) don't fail at configuration time.
-        if (pkgcldRepoUrl) {
-            maven {
-                name = "PackageCloud"
-                url = uri(pkgcldRepoUrl)
-                authentication {
-                    header(HttpHeaderAuthentication)
-                }
-                credentials(HttpHeaderCredentials) {
-                    name = "Authorization"
-                    value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
-                }
+        maven {
+            name = "PackageCloud"
+            url = uri(pkgcldRepoUrl)
+            authentication {
+                header(HttpHeaderAuthentication)
+            }
+            credentials(HttpHeaderCredentials) {
+                name = "Authorization"
+                value = "Bearer " + (System.getenv("PKGCLD_WRITE_TOKEN") ?: project.findProperty("pkgcldWriteToken"))
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ publishing {
     repositories {
         maven {
             name = "PackageCloud"
-            url = uri(System.getenv("PKGCLD_REPO_URL")
+            url = uri(System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeckpro/maven2")
             authentication {
                 header(HttpHeaderAuthentication)
             }

--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ publishing {
     repositories {
         maven {
             name = "PackageCloud"
-            url = uri(System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeckpro/maven2")
+            url = uri(System.getenv("PKGCLD_REPO_URL")
             authentication {
                 header(HttpHeaderAuthentication)
             }

--- a/build.gradle
+++ b/build.gradle
@@ -136,12 +136,11 @@ nexusPublishing {
 
 apply from: "${rootDir}/gradle/publishing.gradle"
 
-// Add PackageCloud repository
 publishing {
     repositories {
         maven {
-            name = "PackageCloudTest"
-            url = uri("https://packagecloud.io/pagerduty/rundeckpro-test/maven2")
+            name = "PackageCloud"
+            url = uri(System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeckpro/maven2")
             authentication {
                 header(HttpHeaderAuthentication)
             }

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ publishing {
     repositories {
         maven {
             name = "PackageCloud"
-            url = uri(System.getenv("PKGCLD_REPO_URL") ?: "https://packagecloud.io/pagerduty/rundeckpro/maven2")
+            url = uri(System.getenv("PKGCLD_REPO_URL"))
             authentication {
                 header(HttpHeaderAuthentication)
             }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'groovy'
     id 'idea'
     alias(libs.plugins.axionRelease)
-    alias(libs.plugins.nexusPublish)
 }
 
 group = 'org.rundeck.plugins'
@@ -123,16 +122,6 @@ test {
 
 //set jar task to depend on copyToLib
 jar.dependsOn(copyToLib)
-
-nexusPublishing {
-    packageGroup = 'org.rundeck.plugins'
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
-}
 
 apply from: "${rootDir}/gradle/publishing.gradle"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ spock = "2.4-groovy-4.0"
 cglib = "3.3.0"
 objenesis = "3.5"
 axionRelease = "1.21.2"
-nexusPublish = "2.0.0"
 # Security overrides for transitive dependencies
 commonsLang3 = "3.20.0"
 
@@ -40,4 +39,3 @@ testLibs = ["junit", "groovyAll", "spockCore", "cglibNodep", "objenesis"]
 
 [plugins]
 axionRelease = { id = "pl.allegro.tech.build.axion-release", version.ref = "axionRelease" }
-nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -6,14 +6,12 @@
  * githubSlug = Github slug e.g. 'rundeck/rundeck-cli'
  * developers = [ [id:'id', name:'name', email: 'email' ] ] list of developers
  *
- * Define project properties to sign and publish when invoking publish task:
+ * Define project properties to sign when invoking the publish task:
  *
  *     ./gradlew \
  *     -PsigningKey="base64 encoded gpg key" \
  *     -PsigningPassword="password for key" \
- *     -PsonatypeUsername="sonatype token user" \
- *     -PsonatypePassword="sonatype token password" \
- *     publishToSonatype closeAndReleaseSonatypeStagingRepository
+ *     publishAllPublicationsToPackageCloudRepository
  */
 apply plugin: 'maven-publish'
 apply plugin: 'signing'

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -5,16 +5,8 @@
  * publishDescription = 'description' (optional)
  * githubSlug = Github slug e.g. 'rundeck/rundeck-cli'
  * developers = [ [id:'id', name:'name', email: 'email' ] ] list of developers
- *
- * Define project properties to sign when invoking the publish task:
- *
- *     ./gradlew \
- *     -PsigningKey="base64 encoded gpg key" \
- *     -PsigningPassword="password for key" \
- *     publishAllPublicationsToPackageCloudRepository
  */
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 publishing {
     publications {
@@ -52,17 +44,5 @@ publishing {
             }
 
         }
-    }
-}
-def base64Decode = { String prop ->
-    project.findProperty(prop) ?
-            new String(Base64.getDecoder().decode(project.findProperty(prop).toString())).trim() :
-            null
-}
-
-if (project.hasProperty('signingKey') && project.hasProperty('signingPassword')) {
-    signing {
-        useInMemoryPgpKeys(base64Decode("signingKey"), project.signingPassword)
-        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Jira Ticket
[RUN-4638](https://pagerduty.atlassian.net/browse/RUN-4638) (subtask of [RUN-4570](https://pagerduty.atlassian.net/browse/RUN-4570))

## Summary

Migrate sshj-plugin publishing from Maven Central (Sonatype) to PackageCloud as a pilot for migrating all 29 plugin repos. This is part of the Maven Central publishing limits resolution — plugins account for 67% of the file count and 85% of the release count on Maven Central, but no external project depends on them as Maven dependencies.

## Change

Replace the "Publish to Maven Central" step in the release workflow with "Publish to PackageCloud":

**Before:** `publishToSonatype closeAndReleaseSonatypeStagingRepository` (4 secrets: Sonatype user/pass, GPG key/pass)

**After:** `publishAllPublicationsToPackageCloudRepository` (1 secret: PKGCLD_WRITE_TOKEN)

## Why this is safe

- The sshj-plugin is bundled into the Rundeck distribution (Docker images, deb/rpm packages) during the build process
- No external project depends on `org.rundeck.plugins:sshj-plugin` as a Maven dependency
- Both `rundeck/build.gradle` and `rundeckpro/build.gradle` already have `packagecloud.io/pagerduty/rundeckpro-test/maven2` configured as a Gradle repository
- The `build.gradle` in this repo already has the PackageCloud publishing repository configured
- Previously published versions remain on Maven Central (immutable)

## Prerequisites

- [x] Verify `PKGCLD_WRITE_TOKEN` secret exists in the `rundeck-plugins` GitHub org

## Test Plan

- [ ] Merge this PR
- [ ] Tag a test version to trigger the release workflow
- [ ] Verify the artifact appears in PackageCloud at `packagecloud.io/pagerduty/rundeck-plugins`
- [ ] Verify `./gradlew build -x check` in rundeck/rundeckpro resolves the plugin from PackageCloud


Made with [Cursor](https://cursor.com)
