### PR TITLE
[RUN-4678] Remove unused net.i2p.crypto:eddsa dependency (CVE-2020-36843)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,6 @@ configurations{
 dependencies {
     pluginLibs libs.sshj
     pluginLibs libs.asnOne
-    pluginLibs libs.eddsa
     pluginLibs libs.bundles.bouncycastle
     pluginLibs libs.expectitCore
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 sshj = "0.40.0"
 asnOne = "0.6.0"
-eddsa = "0.3.0"
 bouncycastle = "1.84"
 expectit = "0.9.0"
 commonsIo = "2.22.0"
@@ -20,7 +19,6 @@ commonsLang3 = "3.20.0"
 [libraries]
 sshj = { group = "com.hierynomus", name = "sshj", version.ref = "sshj" }
 asnOne = { group = "com.hierynomus", name = "asn-one", version.ref = "asnOne" }
-eddsa = { group = "net.i2p.crypto", name = "eddsa", version.ref = "eddsa" }
 bcpkix = { group = "org.bouncycastle", name = "bcpkix-jdk18on", version.ref = "bouncycastle" }
 bcprov = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
 expectitCore = { group = "net.sf.expectit", name = "expectit-core", version.ref = "expectit" }


### PR DESCRIPTION
## Summary

Removes the `net.i2p.crypto:eddsa:0.3.0` dependency, resolving [RUN-4678](https://pagerduty.atlassian.net/browse/RUN-4678) / [CVE-2020-36843](https://nvd.nist.gov/vuln/detail/CVE-2020-36843) (signature malleability in EdDSA-Java, unmaintained upstream project). Same fix as [rundeck/rundeck#10394](https://github.com/rundeck/rundeck/pull/10394), applied here since this plugin declared the identical unused dependency.

## Why this is safe

- `net.i2p.crypto:eddsa` was a standalone dependency (`build.gradle` + `gradle/libs.versions.toml`) — confirmed via the resolved `pluginLibs` dependency tree that nothing (sshj, asn-one, BouncyCastle) requires it transitively.
- `sshj` 0.40.0's Ed25519 support goes through the standard JCA `"Ed25519"` algorithm name, not through `net.i2p.crypto.eddsa` classes directly.
- No source in this repo references `net.i2p.crypto.eddsa`/`EdDSA`/`Ed25519` directly.
- Ed25519 is natively supported by the JDK since Java 15 (JEP 339); this module targets Java 17. BouncyCastle (`bcprov-jdk18on`/`bcpkix-jdk18on`) is also already pulled in transitively by `sshj` itself.
- The sibling `rundeck-plugins/git-plugin` repo independently arrived at the same conclusion — its `GitManager.groovy` explicitly strips the `EdDSA` security provider at runtime if present, with a comment noting it "causes `ClassNotFoundException` due to Rundeck's plugin classloader isolation" and that native JDK 15+ support should be used instead.

## Test plan

- [x] `./gradlew dependencies --configuration pluginLibs` — confirmed `net.i2p.crypto:eddsa` no longer appears in the resolved graph
- [x] `./gradlew clean build` — passes (compile, tests, javadoc, jar)
- [x] Standalone smoke test exercising `sshj`'s `SignatureEdDSA` class directly (Ed25519 keygen, sign, verify) against this plugin's actual runtime classpath with the eddsa jar absent — signing and verification succeed via the JDK's native JCA provider